### PR TITLE
Fix monitoring subscription issue

### DIFF
--- a/modules/distribution/README.md
+++ b/modules/distribution/README.md
@@ -3,8 +3,8 @@
 This module creates following resources.
 
 - `aws_cloudfront_distribution`
-- `aws_cloudfront_monitoring_subscription`
 - `aws_cloudfront_origin_access_identity`
+- `aws_cloudfront_monitoring_subscription` (optional)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/modules/distribution/monitoring.tf
+++ b/modules/distribution/monitoring.tf
@@ -3,11 +3,13 @@
 ###################################################
 
 resource "aws_cloudfront_monitoring_subscription" "this" {
+  count = var.monitoring_realtime_metrics_enabled ? 1 : 0
+
   distribution_id = aws_cloudfront_distribution.this.id
 
   monitoring_subscription {
     realtime_metrics_subscription_config {
-      realtime_metrics_subscription_status = var.monitoring_realtime_metrics_enabled ? "Enabled" : "Disabled"
+      realtime_metrics_subscription_status = "Enabled"
     }
   }
 }

--- a/modules/distribution/outputs.tf
+++ b/modules/distribution/outputs.tf
@@ -236,7 +236,7 @@ output "ordered_behaviors" {
       origin_request_policy   = behavior.origin_request_policy_id
       response_headers_policy = behavior.response_headers_policy_id
 
-      function_associations = var.ordered_behaviors[idx].function_associations
+      function_associations = try(var.ordered_behaviors[idx].function_associations, {})
 
       cache_ttl = (var.ordered_behaviors[idx].cache_policy == null
         ? {
@@ -270,7 +270,7 @@ output "monitoring" {
     `realtime_metrics_enabled` - Whether to enable additional real-time metrics for the distribution.
   EOF
   value = {
-    realtime_metrics_enabled = aws_cloudfront_monitoring_subscription.this.monitoring_subscription[0].realtime_metrics_subscription_config[0].realtime_metrics_subscription_status == "Enabled"
+    realtime_metrics_enabled = var.monitoring_realtime_metrics_enabled
   }
 }
 


### PR DESCRIPTION
### Background

- FIx issue on monitoring subscription

```bash
╷
│ Error: error reading CloudFront Monitoring Subscription (XXXXXXXXXXX): NoSuchMonitoringSubscription: The monitoring subscription does not exist.
│ 	status code: 404, request id: 39af21ae-c613-4bd6-badb-270c2542d1f5
│
│   with module.distribution["test"].aws_cloudfront_monitoring_subscription.this,
│   on .terraform/modules/distribution/modules/distribution/monitoring.tf line 5, in resource "aws_cloudfront_monitoring_subscription" "this":
│    5: resource "aws_cloudfront_monitoring_subscription" "this" {
│
╵
```