### PR TITLE
Add cache-policy module

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,3 +1,5 @@
 # Modules
 ":floppy_disk: distribution":
 - modules/distribution/**/*
+":floppy_disk: cache-policy":
+- modules/cache-policy/**/*

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -43,3 +43,6 @@
 - color: "fbca04"
   description: "This issue or pull request is related to distribution module."
   name: ":floppy_disk: distribution"
+- color: "fbca04"
+  description: "This issue or pull request is related to cache-policy module."
+  name: ":floppy_disk: cache-policy"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Terraform Modules from [this package](https://github.com/tedilabs/terraform-aws-
 - **AWS CloudFront**
   - Distribution
   - Real-time Log Configuration (Comming soon!)
+  - Policies
+    - Cache Policy
 
 
 ## Self Promotion

--- a/examples/cloudfront-policies/main.tf
+++ b/examples/cloudfront-policies/main.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+
+###################################################
+# CloudFront Policies
+###################################################
+
+module "cache_policy" {
+  source = "../../modules/cache-policy"
+  # source  = "tedilabs/cloudfront/aws//modules/cache-policy"
+  # version = "~> 0.2.0"
+
+  name        = "example-cache-policy"
+  description = "Managed by Terraform."
+
+  default_ttl = 60 * 60 * 24
+  min_ttl     = 10
+  max_ttl     = 60 * 60 * 24 * 3
+
+  supported_compression_formats = ["BROTLI", "GZIP"]
+
+  cache_keys_in_cookies = {
+    behavior = "NONE"
+  }
+  cache_keys_in_headers = {
+    behavior = "WHITELIST"
+    items    = ["X-User-Id"]
+  }
+  cache_keys_in_query_strings = {
+    behavior = "ALL"
+  }
+}

--- a/examples/cloudfront-policies/outputs.tf
+++ b/examples/cloudfront-policies/outputs.tf
@@ -1,0 +1,3 @@
+output "cache_policy" {
+  value = module.cache_policy
+}

--- a/examples/cloudfront-policies/versions.tf
+++ b/examples/cloudfront-policies/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/cache-policy/README.md
+++ b/modules/cache-policy/README.md
@@ -1,0 +1,60 @@
+# cache-policy
+
+This module creates following resources.
+
+- `aws_cloudfront_cache_policy`
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudfront_cache_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | (Required) A unique name to identify the CloudFront Cache Policy. | `string` | n/a | yes |
+| <a name="input_cache_keys_in_cookies"></a> [cache\_keys\_in\_cookies](#input\_cache\_keys\_in\_cookies) | (Optional) A configuraiton for specifying which cookies to use as cache key in viewer requests. The values in the cache key are automatically forwarded in requests to the origin. `cache_keys_in_cookies` as defined below.<br>    (Required) `behavior` - Determine whether any cookies in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `NONE`, `WHITELIST`, `BLACKLIST`, `ALL`.<br>    (Optional) `items` - A list of cookie names. | <pre>object({<br>    behavior = optional(string, "NONE")<br>    items    = optional(set(string), [])<br>  })</pre> | `{}` | no |
+| <a name="input_cache_keys_in_headers"></a> [cache\_keys\_in\_headers](#input\_cache\_keys\_in\_headers) | (Optional) A configuraiton for specifying which headers to use as cache key in viewer requests. The values in the cache key are automatically forwarded in requests to the origin. `cache_keys_in_headers` as defined below.<br>    (Required) `behavior` - Determine whether any headers in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `NONE`, `WHITELIST`.<br>    (Optional) `items` - A list of header names. | <pre>object({<br>    behavior = optional(string, "NONE")<br>    items    = optional(set(string), [])<br>  })</pre> | `{}` | no |
+| <a name="input_cache_keys_in_query_strings"></a> [cache\_keys\_in\_query\_strings](#input\_cache\_keys\_in\_query\_strings) | (Optional) A configuraiton for specifying which query strings to use as cache key in viewer requests. The values in the cache key are automatically forwarded in requests to the origin. `cache_keys_in_query_strings` as defined below.<br>    (Required) `behavior` - Determine whether any query strings in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `NONE`, `WHITELIST`, `BLACKLIST`, `ALL`.<br>    (Optional) `items` - A list of query string names. | <pre>object({<br>    behavior = optional(string, "NONE")<br>    items    = optional(set(string), [])<br>  })</pre> | `{}` | no |
+| <a name="input_default_ttl"></a> [default\_ttl](#input\_default\_ttl) | (Optional) The default time to live in seconds. The amount of time is that you want objects to stay in the CloudFront cache before another request to the origin to see if the object has been updated. Defaults to `86400` (one day). | `number` | `86400` | no |
+| <a name="input_description"></a> [description](#input\_description) | (Optional) The description of the cache policy. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_max_ttl"></a> [max\_ttl](#input\_max\_ttl) | (Optional) The maximum time to live in seconds. The amount of time is that you want objects to stay in the CloudFront cache before another request to the origin to see if the object has been updated. Defaults to `31536000` (one year). | `number` | `31536000` | no |
+| <a name="input_min_ttl"></a> [min\_ttl](#input\_min\_ttl) | (Optional) The minimum time to live in seconds. The amount of time is that you want objects to stay in the CloudFront cache before another request to the origin to see if the object has been updated. Defaults to `1`. | `number` | `1` | no |
+| <a name="input_supported_compression_formats"></a> [supported\_compression\_formats](#input\_supported\_compression\_formats) | (Optional) A list of compression formats to enable CloudFront to request and cache objects that are compressed in these compression formats, when the viewer supports it. These setting also allow CloudFront's automatic compression to work. Valid values are `BROTLI` and `GZIP`. | `set(string)` | <pre>[<br>  "BROTLI",<br>  "GZIP"<br>]</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cache_keys_in_cookies"></a> [cache\_keys\_in\_cookies](#output\_cache\_keys\_in\_cookies) | A configuraiton for specifying which cookies to use as cache key in viewer requests. |
+| <a name="output_cache_keys_in_headers"></a> [cache\_keys\_in\_headers](#output\_cache\_keys\_in\_headers) | A configuraiton for specifying which headers to use as cache key in viewer requests. |
+| <a name="output_cache_keys_in_query_strings"></a> [cache\_keys\_in\_query\_strings](#output\_cache\_keys\_in\_query\_strings) | A configuraiton for specifying which query\_strings to use as cache key in viewer requests. |
+| <a name="output_default_ttl"></a> [default\_ttl](#output\_default\_ttl) | The default time to live in seconds. |
+| <a name="output_description"></a> [description](#output\_description) | The description of the cache policy. |
+| <a name="output_etag"></a> [etag](#output\_etag) | The current version of the cache policy. |
+| <a name="output_id"></a> [id](#output\_id) | The identifier for the CloudFront cache policy. |
+| <a name="output_max_ttl"></a> [max\_ttl](#output\_max\_ttl) | The maximum time to live in seconds. |
+| <a name="output_min_ttl"></a> [min\_ttl](#output\_min\_ttl) | The minimum time to live in seconds. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the CloudFront cache policy. |
+| <a name="output_supported_compression_formats"></a> [supported\_compression\_formats](#output\_supported\_compression\_formats) | The list of compression formats to enable CloudFront to request and cache objects that are compressed in these compression formats, when the viewer supports it |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cache-policy/main.tf
+++ b/modules/cache-policy/main.tf
@@ -1,0 +1,70 @@
+locals {
+  metadata = {
+    package = "terraform-aws-cloudfront"
+    version = trimspace(file("${path.module}/../../VERSION"))
+    module  = basename(path.module)
+    name    = var.name
+  }
+}
+
+locals {
+  cache_behaviors = {
+    "NONE"      = "none"
+    "WHITELIST" = "whitelist"
+    "BLACKLIST" = "allExcept"
+    "ALL"       = "all"
+  }
+}
+
+
+###################################################
+# Cache Policy for CloudFront Distribution
+###################################################
+
+resource "aws_cloudfront_cache_policy" "this" {
+  name    = var.name
+  comment = var.description
+
+  default_ttl = var.default_ttl
+  min_ttl     = var.min_ttl
+  max_ttl     = var.max_ttl
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    enable_accept_encoding_brotli = contains(var.supported_compression_formats, "BROTLI")
+    enable_accept_encoding_gzip   = contains(var.supported_compression_formats, "GZIP")
+
+    cookies_config {
+      cookie_behavior = local.cache_behaviors[var.cache_keys_in_cookies.behavior]
+
+      dynamic "cookies" {
+        for_each = contains(["WHITELIST", "BLACKLIST"], var.cache_keys_in_cookies.behavior) ? [var.cache_keys_in_cookies] : []
+
+        content {
+          items = cookies.value.items
+        }
+      }
+    }
+    headers_config {
+      header_behavior = local.cache_behaviors[var.cache_keys_in_headers.behavior]
+
+      dynamic "headers" {
+        for_each = contains(["WHITELIST"], var.cache_keys_in_headers.behavior) ? [var.cache_keys_in_headers] : []
+
+        content {
+          items = headers.value.items
+        }
+      }
+    }
+    query_strings_config {
+      query_string_behavior = local.cache_behaviors[var.cache_keys_in_query_strings.behavior]
+
+      dynamic "query_strings" {
+        for_each = contains(["WHITELIST", "BLACKLIST"], var.cache_keys_in_query_strings.behavior) ? [var.cache_keys_in_query_strings] : []
+
+        content {
+          items = query_strings.value.items
+        }
+      }
+    }
+  }
+}

--- a/modules/cache-policy/outputs.tf
+++ b/modules/cache-policy/outputs.tf
@@ -1,0 +1,72 @@
+output "id" {
+  description = "The identifier for the CloudFront cache policy."
+  value       = aws_cloudfront_cache_policy.this.id
+}
+
+output "etag" {
+  description = "The current version of the cache policy."
+  value       = aws_cloudfront_cache_policy.this.etag
+}
+
+output "name" {
+  description = "The name of the CloudFront cache policy."
+  value       = aws_cloudfront_cache_policy.this.name
+}
+
+output "description" {
+  description = "The description of the cache policy."
+  value       = aws_cloudfront_cache_policy.this.comment
+}
+
+output "default_ttl" {
+  description = "The default time to live in seconds."
+  value       = aws_cloudfront_cache_policy.this.default_ttl
+}
+
+output "min_ttl" {
+  description = "The minimum time to live in seconds."
+  value       = aws_cloudfront_cache_policy.this.min_ttl
+}
+
+output "max_ttl" {
+  description = "The maximum time to live in seconds."
+  value       = aws_cloudfront_cache_policy.this.max_ttl
+}
+
+output "supported_compression_formats" {
+  description = "The list of compression formats to enable CloudFront to request and cache objects that are compressed in these compression formats, when the viewer supports it"
+  value       = var.supported_compression_formats
+}
+
+output "cache_keys_in_cookies" {
+  description = "A configuraiton for specifying which cookies to use as cache key in viewer requests."
+  value = {
+    behavior = {
+      for k, v in local.cache_behaviors :
+      v => k
+    }[aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].cookies_config[0].cookie_behavior]
+    items = try(aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].cookies_config[0].cookies[0].items, toset([]))
+  }
+}
+
+output "cache_keys_in_headers" {
+  description = "A configuraiton for specifying which headers to use as cache key in viewer requests."
+  value = {
+    behavior = {
+      for k, v in local.cache_behaviors :
+      v => k
+    }[aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].headers_config[0].header_behavior]
+    items = try(aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].headers_config[0].headers[0].items, toset([]))
+  }
+}
+
+output "cache_keys_in_query_strings" {
+  description = "A configuraiton for specifying which query_strings to use as cache key in viewer requests."
+  value = {
+    behavior = {
+      for k, v in local.cache_behaviors :
+      v => k
+    }[aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].query_strings_config[0].query_string_behavior]
+    items = try(aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].query_strings_config[0].query_strings[0].items, toset([]))
+  }
+}

--- a/modules/cache-policy/variables.tf
+++ b/modules/cache-policy/variables.tf
@@ -1,0 +1,104 @@
+variable "name" {
+  description = "(Required) A unique name to identify the CloudFront Cache Policy."
+  type        = string
+}
+
+variable "description" {
+  description = "(Optional) The description of the cache policy."
+  type        = string
+  default     = "Managed by Terraform."
+  nullable    = false
+}
+
+variable "default_ttl" {
+  description = "(Optional) The default time to live in seconds. The amount of time is that you want objects to stay in the CloudFront cache before another request to the origin to see if the object has been updated. Defaults to `86400` (one day)."
+  type        = number
+  default     = 86400
+  nullable    = false
+}
+
+variable "min_ttl" {
+  description = "(Optional) The minimum time to live in seconds. The amount of time is that you want objects to stay in the CloudFront cache before another request to the origin to see if the object has been updated. Defaults to `1`."
+  type        = number
+  default     = 1
+  nullable    = false
+}
+
+variable "max_ttl" {
+  description = "(Optional) The maximum time to live in seconds. The amount of time is that you want objects to stay in the CloudFront cache before another request to the origin to see if the object has been updated. Defaults to `31536000` (one year)."
+  type        = number
+  default     = 31536000
+  nullable    = false
+}
+
+variable "supported_compression_formats" {
+  description = "(Optional) A list of compression formats to enable CloudFront to request and cache objects that are compressed in these compression formats, when the viewer supports it. These setting also allow CloudFront's automatic compression to work. Valid values are `BROTLI` and `GZIP`."
+  type        = set(string)
+  default     = ["BROTLI", "GZIP"]
+  nullable    = false
+
+  validation {
+    condition = alltrue([
+      for format in var.supported_compression_formats :
+      contains(["BROTLI", "GZIP"], format)
+    ])
+    error_message = "Valid values are `BROTLI` and `GZIP`."
+  }
+}
+
+variable "cache_keys_in_cookies" {
+  description = <<EOF
+  (Optional) A configuraiton for specifying which cookies to use as cache key in viewer requests. The values in the cache key are automatically forwarded in requests to the origin. `cache_keys_in_cookies` as defined below.
+    (Required) `behavior` - Determine whether any cookies in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `NONE`, `WHITELIST`, `BLACKLIST`, `ALL`.
+    (Optional) `items` - A list of cookie names.
+  EOF
+  type = object({
+    behavior = optional(string, "NONE")
+    items    = optional(set(string), [])
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["NONE", "WHITELIST", "BLACKLIST", "ALL"], var.cache_keys_in_cookies.behavior)
+    error_message = "Valid values for `behavior` are `NONE`, `WHITELIST`, `BLACKLIST` and `ALL`."
+  }
+}
+
+variable "cache_keys_in_headers" {
+  description = <<EOF
+  (Optional) A configuraiton for specifying which headers to use as cache key in viewer requests. The values in the cache key are automatically forwarded in requests to the origin. `cache_keys_in_headers` as defined below.
+    (Required) `behavior` - Determine whether any headers in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `NONE`, `WHITELIST`.
+    (Optional) `items` - A list of header names.
+  EOF
+  type = object({
+    behavior = optional(string, "NONE")
+    items    = optional(set(string), [])
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["NONE", "WHITELIST"], var.cache_keys_in_headers.behavior)
+    error_message = "Valid values for `behavior` are `NONE` and `WHITELIST`."
+  }
+}
+
+variable "cache_keys_in_query_strings" {
+  description = <<EOF
+  (Optional) A configuraiton for specifying which query strings to use as cache key in viewer requests. The values in the cache key are automatically forwarded in requests to the origin. `cache_keys_in_query_strings` as defined below.
+    (Required) `behavior` - Determine whether any query strings in viewer requests are included in the cache key and automatically included in requests that CloudFront sends to the origin. Valid values are `NONE`, `WHITELIST`, `BLACKLIST`, `ALL`.
+    (Optional) `items` - A list of query string names.
+  EOF
+  type = object({
+    behavior = optional(string, "NONE")
+    items    = optional(set(string), [])
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["NONE", "WHITELIST", "BLACKLIST", "ALL"], var.cache_keys_in_query_strings.behavior)
+    error_message = "Valid values for `behavior` are `NONE`, `WHITELIST`, `BLACKLIST` and `ALL`."
+  }
+}

--- a/modules/cache-policy/versions.tf
+++ b/modules/cache-policy/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `cache-policy` module to support CloudFront Cache Policy