### PR TITLE
Add origin-request-policy module

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -3,3 +3,5 @@
 - modules/distribution/**/*
 ":floppy_disk: cache-policy":
 - modules/cache-policy/**/*
+":floppy_disk: origin-request-policy":
+- modules/origin-request-policy/**/*

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -46,3 +46,6 @@
 - color: "fbca04"
   description: "This issue or pull request is related to cache-policy module."
   name: ":floppy_disk: cache-policy"
+- color: "fbca04"
+  description: "This issue or pull request is related to origin-request-policy module."
+  name: ":floppy_disk: origin-request-policy"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Terraform Modules from [this package](https://github.com/tedilabs/terraform-aws-
   - Real-time Log Configuration (Comming soon!)
   - Policies
     - Cache Policy
+    - Origin Request Policy
 
 
 ## Self Promotion

--- a/examples/cloudfront-policies/main.tf
+++ b/examples/cloudfront-policies/main.tf
@@ -32,3 +32,23 @@ module "cache_policy" {
     behavior = "ALL"
   }
 }
+
+module "origin_request_policy" {
+  source = "../../modules/origin-request-policy"
+  # source  = "tedilabs/cloudfront/aws//modules/origin-request-policy"
+  # version = "~> 0.2.0"
+
+  name        = "example-origin-request-policy"
+  description = "Managed by Terraform."
+
+  forwarding_cookies = {
+    behavior = "NONE"
+  }
+  forwarding_headers = {
+    behavior = "ALL_VIEWER_AND_CLOUDFRONT_WHITELIST"
+    items    = ["CloudFront-Viewer-Country-Name"]
+  }
+  forwarding_query_strings = {
+    behavior = "ALL"
+  }
+}

--- a/examples/cloudfront-policies/outputs.tf
+++ b/examples/cloudfront-policies/outputs.tf
@@ -1,3 +1,7 @@
 output "cache_policy" {
   value = module.cache_policy
 }
+
+output "origin_request_policy" {
+  value = module.origin_request_policy
+}

--- a/modules/cache-policy/README.md
+++ b/modules/cache-policy/README.md
@@ -48,7 +48,7 @@ No modules.
 |------|-------------|
 | <a name="output_cache_keys_in_cookies"></a> [cache\_keys\_in\_cookies](#output\_cache\_keys\_in\_cookies) | A configuraiton for specifying which cookies to use as cache key in viewer requests. |
 | <a name="output_cache_keys_in_headers"></a> [cache\_keys\_in\_headers](#output\_cache\_keys\_in\_headers) | A configuraiton for specifying which headers to use as cache key in viewer requests. |
-| <a name="output_cache_keys_in_query_strings"></a> [cache\_keys\_in\_query\_strings](#output\_cache\_keys\_in\_query\_strings) | A configuraiton for specifying which query\_strings to use as cache key in viewer requests. |
+| <a name="output_cache_keys_in_query_strings"></a> [cache\_keys\_in\_query\_strings](#output\_cache\_keys\_in\_query\_strings) | A configuraiton for specifying which query strings to use as cache key in viewer requests. |
 | <a name="output_default_ttl"></a> [default\_ttl](#output\_default\_ttl) | The default time to live in seconds. |
 | <a name="output_description"></a> [description](#output\_description) | The description of the cache policy. |
 | <a name="output_etag"></a> [etag](#output\_etag) | The current version of the cache policy. |

--- a/modules/cache-policy/main.tf
+++ b/modules/cache-policy/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 locals {
-  cache_behaviors = {
+  behaviors = {
     "NONE"      = "none"
     "WHITELIST" = "whitelist"
     "BLACKLIST" = "allExcept"
@@ -34,7 +34,7 @@ resource "aws_cloudfront_cache_policy" "this" {
     enable_accept_encoding_gzip   = contains(var.supported_compression_formats, "GZIP")
 
     cookies_config {
-      cookie_behavior = local.cache_behaviors[var.cache_keys_in_cookies.behavior]
+      cookie_behavior = local.behaviors[var.cache_keys_in_cookies.behavior]
 
       dynamic "cookies" {
         for_each = contains(["WHITELIST", "BLACKLIST"], var.cache_keys_in_cookies.behavior) ? [var.cache_keys_in_cookies] : []
@@ -45,7 +45,7 @@ resource "aws_cloudfront_cache_policy" "this" {
       }
     }
     headers_config {
-      header_behavior = local.cache_behaviors[var.cache_keys_in_headers.behavior]
+      header_behavior = local.behaviors[var.cache_keys_in_headers.behavior]
 
       dynamic "headers" {
         for_each = contains(["WHITELIST"], var.cache_keys_in_headers.behavior) ? [var.cache_keys_in_headers] : []
@@ -56,7 +56,7 @@ resource "aws_cloudfront_cache_policy" "this" {
       }
     }
     query_strings_config {
-      query_string_behavior = local.cache_behaviors[var.cache_keys_in_query_strings.behavior]
+      query_string_behavior = local.behaviors[var.cache_keys_in_query_strings.behavior]
 
       dynamic "query_strings" {
         for_each = contains(["WHITELIST", "BLACKLIST"], var.cache_keys_in_query_strings.behavior) ? [var.cache_keys_in_query_strings] : []

--- a/modules/cache-policy/outputs.tf
+++ b/modules/cache-policy/outputs.tf
@@ -42,7 +42,7 @@ output "cache_keys_in_cookies" {
   description = "A configuraiton for specifying which cookies to use as cache key in viewer requests."
   value = {
     behavior = {
-      for k, v in local.cache_behaviors :
+      for k, v in local.behaviors :
       v => k
     }[aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].cookies_config[0].cookie_behavior]
     items = try(aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].cookies_config[0].cookies[0].items, toset([]))
@@ -53,7 +53,7 @@ output "cache_keys_in_headers" {
   description = "A configuraiton for specifying which headers to use as cache key in viewer requests."
   value = {
     behavior = {
-      for k, v in local.cache_behaviors :
+      for k, v in local.behaviors :
       v => k
     }[aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].headers_config[0].header_behavior]
     items = try(aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].headers_config[0].headers[0].items, toset([]))
@@ -61,10 +61,10 @@ output "cache_keys_in_headers" {
 }
 
 output "cache_keys_in_query_strings" {
-  description = "A configuraiton for specifying which query_strings to use as cache key in viewer requests."
+  description = "A configuraiton for specifying which query strings to use as cache key in viewer requests."
   value = {
     behavior = {
-      for k, v in local.cache_behaviors :
+      for k, v in local.behaviors :
       v => k
     }[aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].query_strings_config[0].query_string_behavior]
     items = try(aws_cloudfront_cache_policy.this.parameters_in_cache_key_and_forwarded_to_origin[0].query_strings_config[0].query_strings[0].items, toset([]))

--- a/modules/origin-request-policy/README.md
+++ b/modules/origin-request-policy/README.md
@@ -1,0 +1,52 @@
+# origin-request-policy
+
+This module creates following resources.
+
+- `aws_cloudfront_origin_request_policy`
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudfront_origin_request_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | (Required) A unique name to identify the CloudFront Origin Request Policy. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | (Optional) The description of the origin request policy. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_forwarding_cookies"></a> [forwarding\_cookies](#input\_forwarding\_cookies) | (Optional) A configuraiton for specifying which cookies in viewer requests to be forwarded in the origin requests. `forwarding_cookies` as defined below.<br>    (Required) `behavior` - Determine whether any cookies in viewer requests are forwarded in the origin requests. Valid values are `NONE`, `WHITELIST`, `ALL`.<br>    (Optional) `items` - A list of cookie names. | <pre>object({<br>    behavior = optional(string, "NONE")<br>    items    = optional(set(string), [])<br>  })</pre> | `{}` | no |
+| <a name="input_forwarding_headers"></a> [forwarding\_headers](#input\_forwarding\_headers) | (Optional) A configuraiton for specifying which headers in viewer requests to be forwarded in the origin requests. `forwarding_headers` as defined below.<br>    (Required) `behavior` - Determine whether any headers in viewer requests are forwarded in the origin requests. Valid values are `NONE`, `WHITELIST`, `ALL_VIEWER` and `ALL_VIEWER_AND_CLOUDFRONT_WHITELIST`.<br>    (Optional) `items` - A list of header names. | <pre>object({<br>    behavior = optional(string, "NONE")<br>    items    = optional(set(string), [])<br>  })</pre> | `{}` | no |
+| <a name="input_forwarding_query_strings"></a> [forwarding\_query\_strings](#input\_forwarding\_query\_strings) | (Optional) A configuraiton for specifying which query strings in viewer requests to be forwarded in the origin requests. `forwarding_query_strings` as defined below.<br>    (Required) `behavior` - Determine whether any query strings in viewer requests are forwarded in the origin requests. Valid values are `NONE`, `WHITELIST`, `ALL`.<br>    (Optional) `items` - A list of query string names. | <pre>object({<br>    behavior = optional(string, "NONE")<br>    items    = optional(set(string), [])<br>  })</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_description"></a> [description](#output\_description) | The description of the origin request policy. |
+| <a name="output_etag"></a> [etag](#output\_etag) | The current version of the origin request policy. |
+| <a name="output_forwarding_cookies"></a> [forwarding\_cookies](#output\_forwarding\_cookies) | A configuraiton for specifying which cookies to be forwarded in the origin requests. |
+| <a name="output_forwarding_headers"></a> [forwarding\_headers](#output\_forwarding\_headers) | A configuraiton for specifying which headers to be forwarded in the origin requests. |
+| <a name="output_forwarding_query_strings"></a> [forwarding\_query\_strings](#output\_forwarding\_query\_strings) | A configuraiton for specifying which query strings to be forwarded in the origin requests. |
+| <a name="output_id"></a> [id](#output\_id) | The identifier for the CloudFront origin request policy. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the CloudFront origin request policy. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/origin-request-policy/main.tf
+++ b/modules/origin-request-policy/main.tf
@@ -1,0 +1,63 @@
+locals {
+  metadata = {
+    package = "terraform-aws-cloudfront"
+    version = trimspace(file("${path.module}/../../VERSION"))
+    module  = basename(path.module)
+    name    = var.name
+  }
+}
+
+locals {
+  behaviors = {
+    "NONE"                                = "none"
+    "WHITELIST"                           = "whitelist"
+    "BLACKLIST"                           = "allExcept"
+    "ALL"                                 = "all"
+    "ALL_VIEWER"                          = "allViewer"
+    "ALL_VIEWER_AND_CLOUDFRONT_WHITELIST" = "allViewerAndWhitelistCloudFront"
+  }
+}
+
+
+###################################################
+# Origin Request Policy for CloudFront Distribution
+###################################################
+
+resource "aws_cloudfront_origin_request_policy" "this" {
+  name    = var.name
+  comment = var.description
+
+  cookies_config {
+    cookie_behavior = local.behaviors[var.forwarding_cookies.behavior]
+
+    dynamic "cookies" {
+      for_each = contains(["WHITELIST"], var.forwarding_cookies.behavior) ? [var.forwarding_cookies] : []
+
+      content {
+        items = cookies.value.items
+      }
+    }
+  }
+  headers_config {
+    header_behavior = local.behaviors[var.forwarding_headers.behavior]
+
+    dynamic "headers" {
+      for_each = contains(["WHITELIST", "ALL_VIEWER_AND_CLOUDFRONT_WHITELIST"], var.forwarding_headers.behavior) ? [var.forwarding_headers] : []
+
+      content {
+        items = headers.value.items
+      }
+    }
+  }
+  query_strings_config {
+    query_string_behavior = local.behaviors[var.forwarding_query_strings.behavior]
+
+    dynamic "query_strings" {
+      for_each = contains(["WHITELIST"], var.forwarding_query_strings.behavior) ? [var.forwarding_query_strings] : []
+
+      content {
+        items = query_strings.value.items
+      }
+    }
+  }
+}

--- a/modules/origin-request-policy/outputs.tf
+++ b/modules/origin-request-policy/outputs.tf
@@ -1,0 +1,52 @@
+output "id" {
+  description = "The identifier for the CloudFront origin request policy."
+  value       = aws_cloudfront_origin_request_policy.this.id
+}
+
+output "etag" {
+  description = "The current version of the origin request policy."
+  value       = aws_cloudfront_origin_request_policy.this.etag
+}
+
+output "name" {
+  description = "The name of the CloudFront origin request policy."
+  value       = aws_cloudfront_origin_request_policy.this.name
+}
+
+output "description" {
+  description = "The description of the origin request policy."
+  value       = aws_cloudfront_origin_request_policy.this.comment
+}
+
+output "forwarding_cookies" {
+  description = "A configuraiton for specifying which cookies to be forwarded in the origin requests."
+  value = {
+    behavior = {
+      for k, v in local.behaviors :
+      v => k
+    }[aws_cloudfront_origin_request_policy.this.cookies_config[0].cookie_behavior]
+    items = try(aws_cloudfront_origin_request_policy.this.cookies_config[0].cookies[0].items, toset([]))
+  }
+}
+
+output "forwarding_headers" {
+  description = "A configuraiton for specifying which headers to be forwarded in the origin requests."
+  value = {
+    behavior = {
+      for k, v in local.behaviors :
+      v => k
+    }[aws_cloudfront_origin_request_policy.this.headers_config[0].header_behavior]
+    items = try(aws_cloudfront_origin_request_policy.this.headers_config[0].headers[0].items, toset([]))
+  }
+}
+
+output "forwarding_query_strings" {
+  description = "A configuraiton for specifying which query strings to be forwarded in the origin requests."
+  value = {
+    behavior = {
+      for k, v in local.behaviors :
+      v => k
+    }[aws_cloudfront_origin_request_policy.this.query_strings_config[0].query_string_behavior]
+    items = try(aws_cloudfront_origin_request_policy.this.query_strings_config[0].query_strings[0].items, toset([]))
+  }
+}

--- a/modules/origin-request-policy/variables.tf
+++ b/modules/origin-request-policy/variables.tf
@@ -1,0 +1,68 @@
+variable "name" {
+  description = "(Required) A unique name to identify the CloudFront Origin Request Policy."
+  type        = string
+}
+
+variable "description" {
+  description = "(Optional) The description of the origin request policy."
+  type        = string
+  default     = "Managed by Terraform."
+  nullable    = false
+}
+
+variable "forwarding_cookies" {
+  description = <<EOF
+  (Optional) A configuraiton for specifying which cookies in viewer requests to be forwarded in the origin requests. `forwarding_cookies` as defined below.
+    (Required) `behavior` - Determine whether any cookies in viewer requests are forwarded in the origin requests. Valid values are `NONE`, `WHITELIST`, `ALL`.
+    (Optional) `items` - A list of cookie names.
+  EOF
+  type = object({
+    behavior = optional(string, "NONE")
+    items    = optional(set(string), [])
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["NONE", "WHITELIST", "ALL"], var.forwarding_cookies.behavior)
+    error_message = "Valid values for `behavior` are `NONE`, `WHITELIST`, and `ALL`."
+  }
+}
+
+variable "forwarding_headers" {
+  description = <<EOF
+  (Optional) A configuraiton for specifying which headers in viewer requests to be forwarded in the origin requests. `forwarding_headers` as defined below.
+    (Required) `behavior` - Determine whether any headers in viewer requests are forwarded in the origin requests. Valid values are `NONE`, `WHITELIST`, `ALL_VIEWER` and `ALL_VIEWER_AND_CLOUDFRONT_WHITELIST`.
+    (Optional) `items` - A list of header names.
+  EOF
+  type = object({
+    behavior = optional(string, "NONE")
+    items    = optional(set(string), [])
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["NONE", "WHITELIST", "ALL_VIEWER", "ALL_VIEWER_AND_CLOUDFRONT_WHITELIST"], var.forwarding_headers.behavior)
+    error_message = "Valid values for `behavior` are `NONE`, `WHITELIST`, `ALL_VIEWER` and `ALL_VIEWER_AND_CLOUDFRONT_WHITELIST`."
+  }
+}
+
+variable "forwarding_query_strings" {
+  description = <<EOF
+  (Optional) A configuraiton for specifying which query strings in viewer requests to be forwarded in the origin requests. `forwarding_query_strings` as defined below.
+    (Required) `behavior` - Determine whether any query strings in viewer requests are forwarded in the origin requests. Valid values are `NONE`, `WHITELIST`, `ALL`.
+    (Optional) `items` - A list of query string names.
+  EOF
+  type = object({
+    behavior = optional(string, "NONE")
+    items    = optional(set(string), [])
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["NONE", "WHITELIST", "ALL"], var.forwarding_query_strings.behavior)
+    error_message = "Valid values for `behavior` are `NONE`, `WHITELIST`, and `ALL`."
+  }
+}

--- a/modules/origin-request-policy/versions.tf
+++ b/modules/origin-request-policy/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.22"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `origin-request-policy` module to support CloudFront Origin Request Policy