### PR TITLE
chore: update copyright year to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Like this project? Follow the repository on [GitHub](https://github.com/tedilabs
 
 Provided under the terms of the [Apache License](LICENSE).
 
-Copyright © 2022-2023, [Byungjin Park](https://www.posquit0.com).
+Copyright © 2022-2025, [Byungjin Park](https://www.posquit0.com).


### PR DESCRIPTION
Update the copyright year in README.md from 2022-2023 to 2022-2025.