### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/examples/cloudfront-distribution-simple/main.tf
+++ b/examples/cloudfront-distribution-simple/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "distribution" {
   source = "../../modules/distribution"
   # source  = "tedilabs/cloudfront/aws//modules/distribution"
-  # version = "~> 0.2.0"
+  # version = "~> 0.7.0"
 
   name        = "example"
   description = "Managed by Terraform."

--- a/examples/cloudfront-policies/main.tf
+++ b/examples/cloudfront-policies/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "cache_policy" {
   source = "../../modules/cache-policy"
   # source  = "tedilabs/cloudfront/aws//modules/cache-policy"
-  # version = "~> 0.2.0"
+  # version = "~> 0.7.0"
 
   name        = "example-cache-policy"
   description = "Managed by Terraform."
@@ -36,7 +36,7 @@ module "cache_policy" {
 module "origin_request_policy" {
   source = "../../modules/origin-request-policy"
   # source  = "tedilabs/cloudfront/aws//modules/origin-request-policy"
-  # version = "~> 0.2.0"
+  # version = "~> 0.7.0"
 
   name        = "example-origin-request-policy"
   description = "Managed by Terraform."
@@ -56,7 +56,7 @@ module "origin_request_policy" {
 module "response_headers_policy" {
   source = "../../modules/response-headers-policy"
   # source  = "tedilabs/cloudfront/aws//modules/response-headers-policy"
-  # version = "~> 0.2.0"
+  # version = "~> 0.7.0"
 
   name        = "example-response-headers-policy"
   description = "Managed by Terraform."

--- a/modules/vpc-origin/ram-shares.tf
+++ b/modules/vpc-origin/ram-shares.tf
@@ -13,7 +13,7 @@ locals {
 
 module "share" {
   source  = "tedilabs/organization/aws//modules/ram-share"
-  version = "~> 0.5.0"
+  version = "~> 0.7.0"
 
   for_each = {
     for share in var.shares :


### PR DESCRIPTION
## What & why

The `version` constraints on sibling tedilabs child modules in this repo had drifted several
minor releases behind the latest published versions. This realigns them to the house
`~> MAJOR.MINOR.0` convention (minor floor, not an exact patch pin), so the repo tracks current
releases without re-pinning on every patch. It also refreshes the commented-out registry
alternatives in `examples/`, which are self-references to this repo's own modules and had fallen
five minors behind the current `v0.7.3`.

There are no code changes — every hunk is a version constraint string.

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
| --- | --- | --- | --- | --- |
| `tedilabs/organization/aws//modules/ram-share` | `modules/vpc-origin/ram-shares.tf` | `~> 0.5.0` | `~> 0.7.0` | `v0.7.5` |

### Example docs (commented)

These are the commented-out registry alternatives sitting next to the active local
`../../modules/x` source. All four are self-references to this repository.

| Child module | Path | Before | After | Latest release |
| --- | --- | --- | --- | --- |
| `tedilabs/cloudfront/aws//modules/distribution` | `examples/cloudfront-distribution-simple/main.tf` | `~> 0.2.0` | `~> 0.7.0` | `v0.7.3` |
| `tedilabs/cloudfront/aws//modules/cache-policy` | `examples/cloudfront-policies/main.tf` | `~> 0.2.0` | `~> 0.7.0` | `v0.7.3` |
| `tedilabs/cloudfront/aws//modules/origin-request-policy` | `examples/cloudfront-policies/main.tf` | `~> 0.2.0` | `~> 0.7.0` | `v0.7.3` |
| `tedilabs/cloudfront/aws//modules/response-headers-policy` | `examples/cloudfront-policies/main.tf` | `~> 0.2.0` | `~> 0.7.0` | `v0.7.3` |

## Interface changes between the old and new versions

### `tedilabs/organization/aws//modules/ram-share` — `v0.5.6` -> `v0.7.5`

**Verdict: no interface change. None at all.**

- Added variables: none.
- Removed variables: none.
- Renamed or retyped variables: none.
- Output changes: none.
- New `terraform` / provider version floor: none. `modules/ram-share/versions.tf` is
  byte-identical at both tags and already declared `required_version = ">= 1.12"` and
  `hashicorp/aws >= 6.12` at `v0.5.6`, so this bump introduces no *new* floor.
- Calling code changed to match a new interface: none needed, and none made.

This is stronger than the usual "the variables look compatible" claim — the entire
`modules/ram-share` directory is bit-for-bit identical between the two tags:

```
$ git rev-parse v0.5.6^{tree}:modules/ram-share v0.7.5^{tree}:modules/ram-share
63ef8ac74eb52b71cfe897f4d5ecd7ecb9e7c195
63ef8ac74eb52b71cfe897f4d5ecd7ecb9e7c195

$ git log --oneline v0.5.6..v0.7.5 -- modules/ram-share/
(no output — no commit between the tags touched the path)
```

So this is a pure constraint bump: zero code change and zero new version floor.

Compare: https://github.com/tedilabs/terraform-aws-organization/compare/v0.5.6...v0.7.5

Heads up for the reviewer: that compare page looks large, because `v0.5.6...v0.7.5` contains
plenty of work on *other* modules in `terraform-aws-organization` (`organization-policy`,
`sso-permission-set`, `account`, ...). None of it touches `modules/ram-share`. Don't let the
diff size suggest risk that isn't there.

## Verification

- `terraform fmt -recursive -check .` — **pass**, no reformatting needed.
- `modules/vpc-origin`: `terraform init -backend=false -upgrade` then `terraform validate` —
  **pass**. This is the real proof: `init` resolved the new constraint against the public
  registry and downloaded `tedilabs/organization/aws//modules/ram-share` **v0.7.5** (confirmed in
  `.terraform/modules/modules.json`), and `validate` succeeded against it with no changes to the
  call site.
- `examples/cloudfront-distribution-simple` and `examples/cloudfront-policies`: **could not be
  validated.** `terraform init` fails in both with a provider version conflict that is
  **pre-existing on `main` and unrelated to this PR**: each example's `versions.tf:7` pins
  `hashicorp/aws = "~> 5.0"`, while the local modules they source require `>= 6.0.0`, so no
  release satisfies `~> 5.0, >= 6.0.0, >= 6.20.0`. Deliberately not fixed here — it is outside
  the scope of a constraint-alignment PR and deserves its own change. Note the edits in these
  two files are comment-only and cannot affect resolution either way.
- No `terraform plan` or `terraform apply` was run. All `.terraform/` directories and
  `.terraform.lock.hcl` files created during verification were removed before committing;
  `git status --porcelain` shows only the three intended files.

## Supersedes

- **#50** — `chore(deps): update tedilabs/organization/aws requirement from ~> 0.5.0 to ~> 0.7.0
  in /modules/vpc-origin`

This one is worth describing precisely rather than by the usual rule of thumb. Dependabot
normally pins the exact patch (`~> 0.7.5`), which conflicts with the house minor-floor
convention — but #50 does **not** do that here. Its diff is exactly one line,
`modules/vpc-origin/ram-shares.tf` `~> 0.5.0` -> `~> 0.7.0`, byte-identical to the active change
in this PR. So there is no constraint-style disagreement to resolve.

What this PR adds on top of #50 is the four `examples/` documentation constraints, which
dependabot does not track, plus the interface analysis above. #50 becomes redundant once this
merges. **Leaving #50 open** — not closing it; a maintainer can close it or let it auto-close
when this merges.
