### PR TITLE
fix(examples): correct terraform and provider version constraints

### DIFF
--- a/examples/cloudfront-distribution-simple/versions.tf
+++ b/examples/cloudfront-distribution-simple/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/cloudfront-policies/versions.tf
+++ b/examples/cloudfront-policies/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = "~> 1.6"
+  required_version = "~> 1.12"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What & why

Both example roots in `examples/` pin `hashicorp/aws` to `~> 5.0` (i.e. `< 6.0.0`), but the local
modules they instantiate require `>= 6.20` — `modules/distribution` for one root, and
`modules/cache-policy` / `modules/origin-request-policy` / `modules/response-headers-policy` for the
other. Terraform intersects every constraint in the graph, so the intersection is empty and
`terraform init` hard-fails. The examples are unusable as written.

Verbatim, from `examples/cloudfront-distribution-simple` on `main`:

```
Initializing provider plugins found in the configuration...
- Finding hashicorp/aws versions matching "~> 5.0, >= 6.0.0, >= 6.20.0"...

Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 5.0, >= 6.0.0, >= 6.20.0
```

And from `examples/cloudfront-policies`:

```
- Finding hashicorp/aws versions matching "~> 5.0, >= 6.20.0"...

Error: Failed to query available provider packages

Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints ~> 5.0, >= 6.20.0
```

The `required_version = "~> 1.6"` pins were also off-convention and are corrected in the same pass.

This PR touches **only** `examples/*/versions.tf`. No module code, no docs, no other `*.tf`.

## Convention applied

- terraform: `required_version = "~> x.y"` → `~> 1.12`
- providers: `version = "~> x.0"` → `~> 6.0`

`~> 6.0` is sufficient even though the modules declare `>= 6.20`: Terraform intersects all
constraints in the graph, so `~> 6.0` ∩ `>= 6.20` = `[6.20, 7.0)`. Confirmed below — both roots
resolved to **v6.58.0**. The module floor is therefore deliberately *not* copied into the roots.

## Changed roots

Both roots are init-breaking conflicts; neither was style-only.

| Example root | `required_version` before → after | `aws` before → after | Why |
| --- | --- | --- | --- |
| `examples/cloudfront-distribution-simple` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/distribution` needs `>= 6.20`) |
| `examples/cloudfront-policies` | `~> 1.6` → `~> 1.12` | `~> 5.0` → `~> 6.0` | conflict (`modules/cache-policy` needs `>= 6.20`) |

## Verification

`terraform fmt -recursive -check .` — **passes**.

Per root, `terraform init -backend=false` then `terraform validate`, run serially with a private
`TF_PLUGIN_CACHE_DIR`:

| Example root | Result |
| --- | --- |
| `examples/cloudfront-distribution-simple` | `init OK, validate FAILS` (pre-existing, see below) |
| `examples/cloudfront-policies` | `init OK, validate OK` |

Provider resolution, from a clean `.terraform`/lockfile state:

```
######## cloudfront-distribution-simple
- Finding hashicorp/aws versions matching ">= 6.0.0, ~> 6.0, >= 6.20.0"...
- Installing hashicorp/aws v6.58.0...
- Installed hashicorp/aws v6.58.0 (signed by HashiCorp)
Terraform has been successfully initialized!
######## cloudfront-policies
- Finding hashicorp/aws versions matching "~> 6.0, >= 6.20.0"...
- Installing hashicorp/aws v6.58.0...
- Installed hashicorp/aws v6.58.0 (signed by HashiCorp)
Terraform has been successfully initialized!
```

`terraform validate` for `examples/cloudfront-policies`:

```
Success! The configuration is valid.
```

## Pre-existing failures newly exposed

Until now `examples/cloudfront-distribution-simple` died at provider resolution, so its
configuration was never checked. With `init` able to get past the constraint error, `validate` runs
and hits a **pre-existing** bug in a `modules/distribution` variable validation rule, which
dereferences `origin.origin_access.type` without first handling the case where `origin_access` is
`null` (which is what this example passes):

```
Error: Attempt to get attribute from null value

  on ../../modules/distribution/variables.tf line 404, in variable "custom_origins":
 404:       contains(["CONTROL", "NONE"], origin.origin_access.type)
    ├────────────────
    │ origin.origin_access is null

This value is null, so it does not have any attributes.
```

**This is deliberately NOT fixed in this PR** — it lives in `modules/distribution`, outside this
PR's file scope, and is part of a separate, larger piece of work that has not been approved.
**CI will stay red for `examples/cloudfront-distribution-simple` after this PR merges**, and this PR
does not claim to make it green. Its scope is strictly making the provider constraint resolvable, so
that failures like this one become visible at all.

`examples/cloudfront-policies` has no such problem and is fully green.

## Related PRs

Open PRs in this repo at the time of writing are all dependabot bumps, with file sets disjoint from
this one:

- #50 `chore(deps): update tedilabs/organization/aws requirement ... in /modules/vpc-origin` — touches `modules/**`
- #42 `chore(deps): bump actions/checkout from 4 to 6` — touches `.github/**`
- #41 `chore(deps): bump tj-actions/changed-files from 44 to 47` — touches `.github/**`

None of them touch `examples/*/versions.tf`, so there is no overlap or merge-order dependency.
