### PR TITLE
fix(modules): default `origin_access` so distribution origins validate without it

### DIFF
--- a/modules/distribution/variables.tf
+++ b/modules/distribution/variables.tf
@@ -223,7 +223,7 @@ variable "s3_origins" {
     origin_access = optional(object({
       type = optional(string, "CONTROL")
       id   = optional(string)
-    }))
+    }), {})
     custom_headers = optional(map(string), {})
     origin_shield = optional(object({
       enabled = bool
@@ -344,7 +344,7 @@ variable "custom_origins" {
     origin_access = optional(object({
       type = optional(string, "NONE")
       id   = optional(string)
-    }))
+    }), {})
     protocol_policy     = optional(string, "MATCH_VIEWER")
     ssl_security_policy = optional(string, "TLSv1.1")
     custom_headers      = optional(map(string), {})


### PR DESCRIPTION
## What & why

`examples/cloudfront-distribution-simple` fails `terraform validate` on `main`: the `custom_origins`
variable validation in `modules/distribution` dereferences `origin.origin_access.type` while
`origin_access` is an `optional(object(...))` with no default, so it is `null` whenever a caller does
not set it. The example deliberately sets only `host`, so it hits the null. `modules/distribution`'s
own `main.tf` dereferences the same attribute unguarded too (`custom.value.origin_access.type`,
`s3.value.origin_access.type`), and the variable docs already state per-attribute defaults
(`type` defaults to `NONE` for custom origins, `CONTROL` for S3 origins) — which only makes sense if
the block itself is always present. The fix is therefore to give `origin_access` an empty-object
default in both `s3_origins` and `custom_origins` rather than to guard one validation, so the null
case disappears for validations, `main.tf`, and callers alike. The example is left as-is: not
passing `origin_access` is exactly the "simple" case it is meant to demonstrate.

## Validation matrix

`terraform fmt -check`, `terraform init -backend=false`, `terraform validate` in every directory.
Terraform v1.15.6, `hashicorp/aws` v6.58.0.

| Directory | fmt (before → after) | init (before → after) | validate (before → after) |
| --- | --- | --- | --- |
| `modules/cache-policy` | pass → pass | pass → pass | pass → pass |
| `modules/distribution` | pass → pass | pass → pass | pass → pass ¹ |
| `modules/function` | pass → pass | pass → pass | pass → pass |
| `modules/key-group` | pass → pass | pass → pass | pass → pass |
| `modules/key-value-store` | pass → pass | pass → pass | pass → pass |
| `modules/origin-access-control` | pass → pass | pass → pass | pass → pass |
| `modules/origin-request-policy` | pass → pass | pass → pass | pass → pass |
| `modules/response-headers-policy` | pass → pass | pass → pass | pass → pass |
| `modules/vpc-origin` | pass → pass | pass → pass | pass → pass |
| `examples/cloudfront-distribution-simple` | pass → pass | pass → pass | **FAIL** → pass |
| `examples/cloudfront-policies` | pass → pass | pass → pass | pass → pass |

¹ `modules/distribution` validates standalone both before and after, because with no variable values
supplied `var.custom_origins` / `var.s3_origins` default to `{}` and the broken validation never
iterates. The defect only surfaces through a caller — which is why the example was the thing that
went red.

`terraform fmt -recursive -check .` at repo root: clean before and after.

## Changes

### `modules/distribution/variables.tf` — `origin_access` is never null

Cause: `origin_access` was `optional(object(...))` with no default, so it is `null` when omitted,
but every consumer (two `validation` blocks plus three expressions in `main.tf`) reads
`.type` / `.id` off it without a null check.

`variable "s3_origins"`:

```diff
     origin_access = optional(object({
       type = optional(string, "CONTROL")
       id   = optional(string)
-    }))
+    }), {})
```

`variable "custom_origins"`:

```diff
     origin_access = optional(object({
       type = optional(string, "NONE")
       id   = optional(string)
-    }))
+    }), {})
```

With the default in place, an omitted (or explicitly `null`) `origin_access` becomes `{}`, whose
optional attribute defaults then apply — `type = "CONTROL"` for S3 origins and `type = "NONE"` for
custom origins, with `id = null`. That is exactly what the variable descriptions already document,
and it is what `main.tf` already assumes:

- `main.tf:150` `origin_access_control_id = s3.value.origin_access.type == "CONTROL" ? s3.value.origin_access.id : null`
- `main.tf:178` `for_each = s3.value.origin_access.type == "IDENTITY" ? ["go"] : []`
- `main.tf:238` `origin_access_control_id = custom.value.origin_access.type == "CONTROL" ? custom.value.origin_access.id : null`

No behaviour change for callers who already pass `origin_access`; callers who omitted it previously
could not get past validation at all.

Note the sibling `origin_shield` blocks are intentionally left without a default — those *are*
guarded (`x.origin_shield != null ? [...] : []` in `main.tf`), so absent-means-absent is correct
there.

## Still failing

Nothing. Every `modules/*` and `examples/*` directory passes fmt + init + validate after this
change.

## Verification

- Ran fmt / `init -backend=false` / `validate` in all 9 module dirs and both example dirs, before and
  after, cleaning `.terraform` and `.terraform.lock.hcl` between dirs.
- Additionally proved the `s3_origins` half of the fix (which no in-repo example exercises) from a
  throwaway root outside the repo that calls `modules/distribution` with an `s3_origins` entry and a
  `custom_origins` entry, both specifying only `host`. That root fails to validate before the change
  and passes after. It is not committed.
- `grep -rn 'source *=' --include='*.md'` finds no HCL example blocks in this repo's Markdown, so
  there were no README examples to check.
- Not verified: `terraform plan` / `apply` were not run (no credentials, and out of scope), so the
  runtime behaviour of `origin_access_control_id = null` on a real distribution is unchanged-by-
  inspection rather than unchanged-by-execution.
