### PR TITLE
fix(examples): drop attributes the HSTS header variable does not declare

### DIFF
--- a/examples/cloudfront-policies/main.tf
+++ b/examples/cloudfront-policies/main.tf
@@ -115,10 +115,6 @@ module "response_headers_policy" {
     enabled  = true
     override = true
 
-    filtering_enabled = true
-    block             = true
-    report            = ""
-
     max_age            = 60 * 60 * 24 * 365
     include_subdomains = true
     preload            = false


### PR DESCRIPTION
## What & why

`examples/cloudfront-policies` passed three attributes to `modules/response-headers-policy`'s
`strict_transport_security_header` variable that the variable's `object(...)` type does not declare:

```hcl
   strict_transport_security_header = {
     enabled  = true
     override = true
 
-    filtering_enabled = true
-    block             = true
-    report            = ""
-
     max_age            = 60 * 60 * 24 * 365
```

The declared attributes are only `enabled`, `override`, `max_age`, `include_subdomains`, `preload`.

**No intent is lost.** The three removed attributes are a copy-paste duplicate of the adjacent
`xss_protection_header` block a few lines below in the same file, which legitimately declares and
uses all three:

```hcl
  xss_protection_header = {
    enabled  = true
    override = true

    filtering_enabled = true
    block             = true
    report            = ""
  }
```

## This was NOT a red build — and that is the interesting part

Terraform **silently discards** attributes that are absent from an `object(...)` type constraint.
So this configuration passed `terraform validate` and simply never took effect. A validate-based
sweep cannot detect this class of bug; only an argument-name cross-check against `variables.tf` can.

Demonstrated with a throwaway root (a local module declaring
`variable "x" { type = object({ a = optional(bool) }) }` called with `{ b = true }`):
`terraform validate` reports **Success** and `b` is gone from the value. That is why the earlier
validation sweep passed this file.

An org-wide cross-check of every module-call argument against the target's declared object attributes
found this as the only remaining instance outside the ones already fixed in
`terraform-aws-data`, `terraform-aws-db` and `terraform-aws-wan`. Every other header variable in this
example was checked attribute by attribute against `modules/response-headers-policy/variables.tf` and
is correct.

## Verification

`examples/cloudfront-policies`: `terraform init -backend=false` + `terraform validate` → Success,
**0 warnings** (it also passed before, as explained above). `terraform fmt -check` passes.
No `terraform plan`/`apply` was run.

## Relationship to other PRs

Disjoint from PR #53, which touched `modules/distribution/variables.tf` only. This PR touches only
`examples/cloudfront-policies/main.tf`.
